### PR TITLE
Fix typo in t8103-j293.dts and t8103-j313.dts

### DIFF
--- a/arch/arm64/boot/dts/apple/t8103-j293.dts
+++ b/arch/arm64/boot/dts/apple/t8103-j293.dts
@@ -42,7 +42,7 @@
 		spi-max-frequency = <8000000>;
 		/*
 		 * cs-setup and cs-hold delays are derived from Apple's ADT
-		 * Mac OS driver meta data secify 45 us for 'cs to clock' and
+		 * Mac OS driver meta data specify 45 us for 'cs to clock' and
 		 * 'clock to cs' delays.
 		 */
 		spi-cs-setup-delay-ns = <20000>;

--- a/arch/arm64/boot/dts/apple/t8103-j313.dts
+++ b/arch/arm64/boot/dts/apple/t8103-j313.dts
@@ -42,7 +42,7 @@
 		spi-max-frequency = <8000000>;
 		/*
 		 * cs-setup and cs-hold delays are derived from Apple's ADT
-		 * Mac OS driver meta data secify 45 us for 'cs to clock' and
+		 * Mac OS driver meta data specify 45 us for 'cs to clock' and
 		 * 'clock to cs' delays.
 		 */
 		spi-cs-setup-delay-ns = <20000>;


### PR DESCRIPTION
Replace line 45 'secify' with 'specify' in both files.